### PR TITLE
Refactored out the custom way of preserving an original exception

### DIFF
--- a/lib/pwned/error.rb
+++ b/lib/pwned/error.rb
@@ -1,11 +1,5 @@
 module Pwned
   class Error < StandardError
-    attr_reader :original_error
-
-    def initialize(message, original_error)
-      @original_error = original_error
-      super(message)
-    end
   end
 
   class TimeoutError < Error

--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -35,16 +35,14 @@ module Pwned
     end
 
     def get_hashes
-      begin
-        open("#{API_URL}#{hashed_password[0..(HASH_PREFIX_LENGTH-1)]}", @request_options) do |io|
-          @hashes = io.read
-        end
-        @hashes
-      rescue Timeout::Error => e
-        raise Pwned::TimeoutError.new(e.message, e)
-      rescue => e
-        raise Pwned::Error.new(e.message, e)
+      open("#{API_URL}#{hashed_password[0..(HASH_PREFIX_LENGTH-1)]}", @request_options) do |io|
+        @hashes = io.read
       end
+      @hashes
+    rescue Timeout::Error => e
+      raise Pwned::TimeoutError, e.message
+    rescue => e
+      raise Pwned::Error, e.message
     end
 
     def match_data

--- a/spec/pwned/password_spec.rb
+++ b/spec/pwned/password_spec.rb
@@ -52,9 +52,17 @@ RSpec.describe Pwned::Password do
     end
 
     it "raises a custom error" do
-      expect { password.pwned? }.to raise_error(Pwned::TimeoutError)
-      expect { password.pwned_count }.to raise_error(Pwned::TimeoutError)
+      expect { password.pwned? }.to raise_error(&method(:verify_timeout_error))
+      expect { password.pwned_count }.to raise_error(&method(:verify_timeout_error))
       expect(@stub).to have_been_requested.times(2)
+    end
+
+    def verify_timeout_error(error)
+      aggregate_failures "testing custom error" do
+        expect(error).to be_kind_of(Pwned::TimeoutError)
+        expect(error.message).to match(/execution expired/)
+        expect(error.cause).to be_kind_of(Net::OpenTimeout)
+      end
     end
   end
 
@@ -64,9 +72,17 @@ RSpec.describe Pwned::Password do
     end
 
     it "raises a custom error" do
-      expect { password.pwned? }.to raise_error(Pwned::Error)
-      expect { password.pwned_count }.to raise_error(Pwned::Error)
+      expect { password.pwned? }.to raise_error(&method(:verify_internal_error))
+      expect { password.pwned_count }.to raise_error(&method(:verify_internal_error))
       expect(@stub).to have_been_requested.times(2)
+    end
+
+    def verify_internal_error(error)
+      aggregate_failures "testing custom error" do
+        expect(error).to be_kind_of(Pwned::Error)
+        expect(error.message).to match(/500/)
+        expect(error.cause).to be_kind_of(OpenURI::HTTPError)
+      end
     end
   end
 
@@ -77,9 +93,17 @@ RSpec.describe Pwned::Password do
     end
 
     it "raises a custom error" do
-      expect { password.pwned? }.to raise_error(Pwned::Error)
-      expect { password.pwned_count }.to raise_error(Pwned::Error)
+      expect { password.pwned? }.to raise_error(&method(:verify_not_found_error))
+      expect { password.pwned_count }.to raise_error(&method(:verify_not_found_error))
       expect(@stub).to have_been_requested.times(2)
+    end
+
+    def verify_not_found_error(error)
+      aggregate_failures "testing custom error" do
+        expect(error).to be_kind_of(Pwned::Error)
+        expect(error.message).to match(/404/)
+        expect(error.cause).to be_kind_of(OpenURI::HTTPError)
+      end
     end
   end
 


### PR DESCRIPTION
Ruby starting with 2.1 has an easy way to track the original exception, or [`cause`](https://ruby-doc.org/core-2.1.0/Exception.html#method-i-cause).

```ruby
begin
  begin
    raise ArgumentError, "Testing"
  rescue
    raise RuntimeError, "Really"
  end
rescue => e
  puts e.inspect
  puts e.cause.inspect
end

#<RuntimeError: Really>
#<ArgumentError: Testing>
```