### PR TITLE
Performance optimizations and style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,13 @@
 ## Ongoing
 
 * 2 major updates
-  * Refactors exception handling with built in Ruby method. [PR #1](https://github.com/philnash/pwned/pull/1) thanks @kpumuk
-  * Passwords must be strings, the initializer will raise a `TypeError` unless `password.is_a? String`. [dbf7697](https://github.com/philnash/pwned/commit/dbf7697e878d87ac74aed1e715cee19b73473369)
+  * Refactors exception handling with built in Ruby method ([PR #1](https://github.com/philnash/pwned/pull/1) thanks [@kpumuk](https://github.com/kpumuk))
+  * Passwords must be strings, the initializer will raise a `TypeError` unless `password.is_a? String`. ([dbf7697](https://github.com/philnash/pwned/commit/dbf7697e878d87ac74aed1e715cee19b73473369))
+
+* Minor updates
+  * SHA1 is only calculated once
+  * Frozen string literal to make sure Ruby does not copy strings over and over again
+  * Removal of `@match_data`, since we only use it to retrieve the counter. Caching the counter instead (all [PR #2](https://github.com/philnash/pwned/pull/2) thanks [@kpumuk](https://github.com/kpumuk))
 
 ## 1.0.0 / 2018-03-06
 


### PR DESCRIPTION
This PR includes:

* SHA1 is only calculated once
* Frozen string literal to make sure Ruby does not copy strings over and over again
* Removal of `@match_data`, since we only use it to retrieve the counter. Caching the counter instead (this way we do not re-apply regex over and over again if there is no match [should not happen, but still])
* ~Unnecessary `begin`/`end` in `get_hashes`~