### PR TITLE
Added simplified accessors Pwned.pwned? and Pwned.pwned_count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   * Refactors exception handling with built in Ruby method ([PR #1](https://github.com/philnash/pwned/pull/1) thanks [@kpumuk](https://github.com/kpumuk))
   * Passwords must be strings, the initializer will raise a `TypeError` unless `password.is_a? String`. ([dbf7697](https://github.com/philnash/pwned/commit/dbf7697e878d87ac74aed1e715cee19b73473369))
   * Added Ruby on Rails validator ([PR #3](https://github.com/philnash/pwned/pull/3))
+  * Added simplified accessors `Pwned.pwned?`` and `Pwned.pwned_count` ([PR #4](https://github.com/philnash/pwned/pull/4))
 
 * Minor updates
   * SHA1 is only calculated once

--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ rescue Pwned::Error => e
 end
 ```
 
+Most of the times you only care if the password has been pwned before or not. You can use simplified accessors to check whether the password has been pwned, or how many times it was pwned:
+
+```ruby
+Pwned.pwned?("password")
+#=> true
+Pwned.pwned_count("password")
+#=> 3303003
+```
+
 #### Advanced
 
 You can set options and headers to be used with `open-uri` when making the request to the API. HTTP headers must be string keys and the [other options are available in the `OpenURI::OpenRead` module](https://ruby-doc.org/stdlib-2.5.0/libdoc/open-uri/rdoc/OpenURI/OpenRead.html#method-i-open).

--- a/lib/pwned.rb
+++ b/lib/pwned.rb
@@ -17,4 +17,13 @@ rescue LoadError
 end
 
 module Pwned
+  # Returns true when the password has been pwned.
+  def self.pwned?(password, request_options={})
+    Pwned::Password.new(password, request_options).pwned?
+  end
+
+  # Returns number of times the password has been pwned.
+  def self.pwned_count(password, request_options={})
+    Pwned::Password.new(password, request_options).pwned_count
+  end
 end

--- a/spec/pwned/password_spec.rb
+++ b/spec/pwned/password_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe Pwned::Password do
       expect(password.pwned?).to be true
       expect(@stub).to have_been_requested
     end
+
+    it "works with simplified accessors" do
+      expect(Pwned.pwned?(password.password)).to be true
+      expect(Pwned.pwned_count(password.password)).to eq(3303003)
+    end
   end
 
   describe "when not pwned", pwned_range: "37D5B" do
@@ -50,6 +55,11 @@ RSpec.describe Pwned::Password do
     it "reports it has been pwned zero times" do
       expect(password.pwned_count).to eq(0)
       expect(@stub).to have_been_requested
+    end
+
+    it "works with simplified accessors" do
+      expect(Pwned.pwned?(password.password)).to be false
+      expect(Pwned.pwned_count(password.password)).to eq(0)
     end
   end
 


### PR DESCRIPTION
Sometimes one only wants to check if the password has been pwned, or how many dumps the password appears in.