### PR TITLE
Performance: read the response dump line by line instead of loading the whole thing in memory

### DIFF
--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -7,6 +7,7 @@ module Pwned
   class Password
     API_URL = "https://api.pwnedpasswords.com/range/"
     HASH_PREFIX_LENGTH = 5
+    SHA1_LENGTH = 40
     DEFAULT_REQUEST_OPTIONS = {
       "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}"
     }.freeze
@@ -37,10 +38,11 @@ module Pwned
     private
 
     def fetch_pwned_count
-      regex = /#{Regexp.escape hashed_password_suffix}:(\d+)/
+      suffix = hashed_password_suffix
       for_each_response_line do |line|
-        count = line[regex, 1]
-        return @pwned_count = count.to_i if count
+        next unless line.start_with?(suffix)
+        # Count starts after the suffix, followed by a colon
+        return @pwned_count = line[(SHA1_LENGTH-HASH_PREFIX_LENGTH+1)..-1].to_i
       end
 
       @pwned_count = 0


### PR DESCRIPTION
The response from the service will grow over time. There is no way to get passwords [unpwned](https://github.com/danielmiessler/SecLists/pull/155), so we can safely assume the list will keep growing, adding more new hashes. One day it will grow large enough to start taking down servers when users "DDoS" applications with known "big" pwned password hash prefixes.

This PR switches from "load everything to memory and find our hash" to "fetch data in chunks, and process line by line".