### PR TITLE
Add a pwned CLI/executable tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ An easy, Ruby way to use the Pwned Passwords API.
   * [Plain Ruby](#plain-ruby)
   * [Rails (ActiveRecord)](#activerecord-validator)
   * [Devise](#devise)
+  * [Command line](#command-line)
 * [How Pwned is Pi?](#how-pwned-is-pi)
 * [Development](#development)
 * [Contributing](#contributing)
@@ -180,6 +181,24 @@ You can configure network requests made from the validator using `:request_optio
 ### Devise
 
 If you are using Devise I recommend you use the [devise-pwned_password extension](https://github.com/michaelbanfield/devise-pwned_password) which is now powered by this gem.
+
+### Command line
+
+The gem provides a command line utility for checking passwords. You can call it from your terminal application like this:
+
+```bash
+$ pwned password
+Pwned!
+The password has been found in public breaches 3645804 times.
+```
+
+If you don't want the password you are checking to be visible, call:
+
+```bash
+$ pwned --secret
+```
+
+You will be prompted for the password, but it won't be displayed.
 
 ## How Pwned is Pi?
 

--- a/bin/pwned
+++ b/bin/pwned
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'pwned'
+require 'io/console'
+
+input = STDIN.getpass("Password: ")
+passw = Pwned::Password.new(input)
+
+if passw.pwned?
+  puts "Your password has been pwned! #{passw.pwned_count} occurrences."
+else
+  puts "Your password seems safe."
+end

--- a/bin/pwned
+++ b/bin/pwned
@@ -1,13 +1,52 @@
 #!/usr/bin/env ruby
 
 require 'pwned'
+require 'optparse'
 require 'io/console'
 
-input = STDIN.getpass("Password: ")
-passw = Pwned::Password.new(input)
+options = {}
+parser = OptionParser.new do |opts|
+  opts.banner = <<-USAGE
+Usage: pwned <password>
 
-if passw.pwned?
-  puts "Your password has been pwned! #{passw.pwned_count} occurrences."
-else
-  puts "Your password seems safe."
+Tests a password against the Pwned Passwords API using the k-anonymity model,
+which avoids sending the entire password to the service.opts
+
+If the password has been found in a publicly available breach then this tool
+will report how many times it has been seen. Otherwise the tool will report that
+the password has not been found in a public breach yet.
+
+USAGE
+
+  opts.version = Pwned::VERSION
+
+  opts.on("-s", "--secret", "Enter password without displaying characters.\n#{" "* 37}Overrides provided arguments.")
+  opts.on_tail("-h", "--help", "Show help.")
+  opts.on_tail("-v", "--version", "Show version number.\n\n")
 end
+
+parser.parse!(ARGV, into: options)
+
+if options[:help]
+  puts parser.help
+  exit
+end
+if options[:version]
+  puts parser.ver
+  exit
+end
+password_to_test = ARGV.first
+if options[:secret]
+  password_to_test = STDIN.getpass("Password: ")
+end
+if !password_to_test || password_to_test.strip == ""
+  puts parser.help
+  exit
+end
+password = Pwned::Password.new(password_to_test || ARGV.first)
+if password.pwned?
+  puts "Pwned!\nThe password has been found in public breaches #{password.pwned_count} times."
+else
+  puts "The password has not been found in a public breach."
+end
+

--- a/pwned.gemspec
+++ b/pwned.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.require_paths = ["lib"]
+  spec.executables = ["pwned"]
 
   spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This takes @chrp's work from #11 and extends it with a bit more CLI stuff.

Honestly, I might have got a bit carried away with this. Possibly over-engineered the situation with `OptionParser` but it doesn't add any more dependencies (yay stdlib) and it does do a bunch of things I'd expect from a CLI. Including:

* Returns help text if you don't pass any arguments
* Returns help text if you pass `-h` or `--help` flags
* Returns the version of the program if you pass the `-v` or `--version` flag

It also allows you to pass a password to be tested directly from calling the executable:

```bash
$ pwned password
Pwned!
The password has been found in public breaches 3645804 times.
```

Or you can pass the `-s` or `--secret` flag and type in the password without it being seen:

```bash
$ pwned --secret
Password: 
Pwned!
The password has been found in public breaches 3645804 times.
```
