### PR TITLE
Add double-splat to ActiveModel::Errors#add calls with options

### DIFF
--- a/lib/pwned/not_pwned_validator.rb
+++ b/lib/pwned/not_pwned_validator.rb
@@ -79,12 +79,12 @@ class NotPwnedValidator < ActiveModel::EachValidator
     begin
       pwned_check = Pwned::Password.new(value, request_options)
       if pwned_check.pwned_count > threshold
-        record.errors.add(attribute, :not_pwned, options.merge(count: pwned_check.pwned_count))
+        record.errors.add(attribute, :not_pwned, **options.merge(count: pwned_check.pwned_count))
       end
     rescue Pwned::Error => error
       case on_error
       when :invalid
-        record.errors.add(attribute, :pwned_error, options.merge(message: options[:error_message]))
+        record.errors.add(attribute, :pwned_error, **options.merge(message: options[:error_message]))
       when :valid
         # Do nothing, consider the record valid
       when Proc


### PR DESCRIPTION
Shush warnings on Ruby 2.7:

    .../gems/pwned-dd7754a624f5/lib/pwned/not_pwned_validator.rb:82: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
    .../gems/rails-de853a296f56/activemodel/lib/active_model/errors.rb:373: warning: The called method `add' is defined here

`ActiveModel::Errors#add` only recently switched to kwargs, but this works with older Ruby and Rails.