### PR TITLE
Fix crash b/c of nil + …

### DIFF
--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -148,7 +148,7 @@ module Pwned
       last_line = ''
 
       response.read_body do |chunk|
-        chunk_lines = (last_line + chunk).lines
+        chunk_lines = (last_line.to_s + chunk).lines
         # This could end with half a line, so save it for next time
         last_line = chunk_lines.pop
         chunk_lines.each(&block)

--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -145,7 +145,7 @@ module Pwned
 
     # Stream a Net::HTTPResponse by line, handling lines that cross chunks.
     def stream_response_lines(response, &block)
-      last_line = ''
+      last_line = nil
 
       response.read_body do |chunk|
         chunk_lines = (last_line.to_s + chunk).lines
@@ -153,7 +153,8 @@ module Pwned
         last_line = chunk_lines.pop
         chunk_lines.each(&block)
       end
-      yield last_line
+
+      yield last_line if last_line
     end
 
   end

--- a/spec/pwned/password_spec.rb
+++ b/spec/pwned/password_spec.rb
@@ -158,6 +158,18 @@ RSpec.describe Pwned::Password do
     it "streams the whole file" do
       expect(password).to be_pwned
     end
+
+    it "works when response stream returns several empty chunks" do
+      response = double
+      allow(response).to receive(:read_body).
+        and_yield("").
+        and_yield("").
+        and_yield("hello\nworld\n")
+
+      password.send(:stream_response_lines, response) do |x|
+        expect(x).to eq("hello\n") | eq("world\n")
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Apparently chunk_lines can sometimes become an empty array and
`last_line` ends up being nil causing an exception on this string
addition. Convert string or nil to string before adding to be sure.