### PR TITLE
Support calling the library asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ An easy, Ruby way to use the Pwned Passwords API.
       - [Threshold](#threshold)
       - [Network Error Handling](#network-error-handling)
       - [Custom Request Options](#custom-request-options)
+    - [Using Asynchronously](#using-asynchronously)
     - [Devise](#devise)
     - [Command line](#command-line)
   - [How Pwned is Pi?](#how-pwned-is-pi)
@@ -185,6 +186,17 @@ In addition to these options, HTTP headers can be specified with the `:headers` 
   validates :password, not_pwned: {
     request_options: { read_timeout: 5, open_timeout: 1, headers: { "User-Agent" => "Super fun user agent" } }
   }
+```
+
+### Using Asynchronously
+
+You may have a use case for hashing the password in advance, and then making the call to the Pwned api later
+(for example if you want to enqueue a job without storing the plaintext password):
+
+```ruby
+hashed_password = Pwned.hash_password(password)
+# some time later
+Pwned::HashPassword.new(hashed_password, request_options).pwned?
 ```
 
 ### Devise

--- a/lib/pwned.rb
+++ b/lib/pwned.rb
@@ -4,6 +4,7 @@ require "digest"
 require "pwned/version"
 require "pwned/error"
 require "pwned/password"
+require "pwned/hashed_password"
 
 begin
   # Load Rails and our custom validator

--- a/lib/pwned.rb
+++ b/lib/pwned.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "digest"
 require "pwned/version"
 require "pwned/error"
 require "pwned/password"
@@ -56,5 +57,18 @@ module Pwned
   # @since 1.1.0
   def self.pwned_count(password, request_options={})
     Pwned::Password.new(password, request_options).pwned_count
+  end
+
+  ##
+  # Returns the full SHA1 hash of the given password in uppercase. This can be safely passed around your code
+  # before making the pwned request (e.g. dropped into a queue table).
+  #
+  # @example
+  #     Pwned.hash_password("password") #=> 5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8
+  #
+  # @param password [String] The password you want to check against the API.
+  # @since TBC
+  def self.hash_password(password)
+    Digest::SHA1.hexdigest(password).upcase
   end
 end

--- a/lib/pwned/hashed_password.rb
+++ b/lib/pwned/hashed_password.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'pwned/password_base'
+
+module Pwned
+  ##
+  # This class represents a hashed password. It does all the work of talking to the
+  # Pwned Passwords API to find out if the password has been pwned.
+  # @see https://haveibeenpwned.com/API/v2#PwnedPasswords
+  class HashedPassword < PasswordBase
+    ##
+    # Creates a new hashed password object.
+    #
+    # @example A simple password with the default request options
+    #     password = Pwned::HashedPassword.new("ABC123")
+    # @example Setting the user agent and the read timeout of the request
+    #     password = Pwned::HashedPassword.new("ABC123", headers: { "User-Agent" => "My user agent" }, read_timout: 10)
+    #
+    # @param hashed_password [String] The hash of the password you want to check against the API.
+    # @param [Hash] request_options Options that can be passed to +Net::HTTP.start+ when
+    #   calling the API
+    # @option request_options [Symbol] :headers ({ "User-Agent" => '"Ruby Pwned::Password #{Pwned::VERSION}" })
+    #   HTTP headers to include in the request
+    # @raise [TypeError] if the password is not a string.
+    # @since 1.1.0
+    def initialize(hashed_password, request_options={})
+      raise TypeError, "hashed_password must be of type String" unless hashed_password.is_a? String
+      @hashed_password = hashed_password
+      @request_options = Hash(request_options).dup
+      @request_headers = Hash(request_options.delete(:headers))
+      @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
+    end
+  end
+end

--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -1,35 +1,13 @@
 # frozen_string_literal: true
 
-require "digest"
-require 'net/http'
+require 'pwned/password_base'
 
 module Pwned
   ##
   # This class represents a password. It does all the work of talking to the
   # Pwned Passwords API to find out if the password has been pwned.
   # @see https://haveibeenpwned.com/API/v2#PwnedPasswords
-  class Password
-    ##
-    # The base URL for the Pwned Passwords API
-    API_URL = "https://api.pwnedpasswords.com/range/"
-
-    ##
-    # The number of characters from the start of the hash of the password that
-    # are used to search for the range of passwords.
-    HASH_PREFIX_LENGTH = 5
-
-    ##
-    # The total length of a SHA1 hash
-    SHA1_LENGTH = 40
-
-    ##
-    # The default request headers that are used to make HTTP requests to the
-    # API. A user agent is provided as requested in the documentation.
-    # @see https://haveibeenpwned.com/API/v2#UserAgent
-    DEFAULT_REQUEST_HEADERS = {
-      "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}"
-    }.freeze
-
+  class Password < PasswordBase
     ##
     # @return [String] the password that is being checked.
     # @since 1.0.0
@@ -54,110 +32,10 @@ module Pwned
     def initialize(password, request_options={})
       raise TypeError, "password must be of type String" unless password.is_a? String
       @password = password
+      @hashed_password = Pwned.hash_password(password)
       @request_options = Hash(request_options).dup
       @request_headers = Hash(request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
     end
-
-    ##
-    # Returns the full SHA1 hash of the given password in uppercase.
-    # @return [String] The full SHA1 hash of the given password.
-    # @since 1.0.0
-    def hashed_password
-      @hashed_password ||= Digest::SHA1.hexdigest(password).upcase
-    end
-
-    ##
-    # @example
-    #     password = Pwned::Password.new("password")
-    #     password.pwned? #=> true
-    #
-    # @return [Boolean] +true+ when the password has been pwned.
-    # @raise [Pwned::Error] if there are errors with the HTTP request.
-    # @raise [Pwned::TimeoutError] if the HTTP request times out.
-    # @since 1.0.0
-    def pwned?
-      pwned_count > 0
-    end
-
-    ##
-    # @example
-    #     password = Pwned::Password.new("password")
-    #     password.pwned_count #=> 3303003
-    #
-    # @return [Integer] the number of times the password has been pwned.
-    # @raise [Pwned::Error] if there are errors with the HTTP request.
-    # @raise [Pwned::TimeoutError] if the HTTP request times out.
-    # @since 1.0.0
-    def pwned_count
-      @pwned_count ||= fetch_pwned_count
-    end
-
-    private
-
-    attr_reader :request_options, :request_headers
-
-    def fetch_pwned_count
-      for_each_response_line do |line|
-        next unless line.start_with?(hashed_password_suffix)
-        # Count starts after the suffix, followed by a colon
-        return line[(SHA1_LENGTH-HASH_PREFIX_LENGTH+1)..-1].to_i
-      end
-
-      # The hash was not found, we can assume the password is not pwned [yet]
-      0
-    end
-
-    def for_each_response_line(&block)
-      begin
-        with_http_response "#{API_URL}#{hashed_password_prefix}" do |response|
-          response.value # raise if request was unsuccessful
-          stream_response_lines(response, &block)
-        end
-      rescue Timeout::Error => e
-        raise Pwned::TimeoutError, e.message
-      rescue => e
-        raise Pwned::Error, e.message
-      end
-    end
-
-    def hashed_password_prefix
-      hashed_password[0...HASH_PREFIX_LENGTH]
-    end
-
-    def hashed_password_suffix
-      hashed_password[HASH_PREFIX_LENGTH..-1]
-    end
-
-    # Make a HTTP GET request given the url and headers.
-    # Yields a `Net::HTTPResponse`.
-    def with_http_response(url, &block)
-      uri = URI(url)
-
-      request = Net::HTTP::Get.new(uri)
-      request.initialize_http_header(request_headers)
-      request_options[:use_ssl] = true
-
-      Net::HTTP.start(uri.host, uri.port, request_options) do |http|
-        http.request(request, &block)
-      end
-    end
-
-    # Stream a Net::HTTPResponse by line, handling lines that cross chunks.
-    def stream_response_lines(response, &block)
-      last_line = ''
-
-      response.read_body do |chunk|
-        chunk_lines = (last_line + chunk).lines
-        # This could end with half a line, so save it for next time. If
-        # chunk_lines is empty, pop returns nil, so this also ensures last_line
-        # is always a string.
-        last_line = chunk_lines.pop || ''
-        chunk_lines.each(&block)
-      end
-
-      yield last_line unless last_line.empty?
-    end
-
   end
 end

--- a/lib/pwned/password_base.rb
+++ b/lib/pwned/password_base.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "digest"
+require 'net/http'
+
+module Pwned
+  ##
+  # This class represents a password. It does all the work of talking to the
+  # Pwned Passwords API to find out if the password has been pwned.
+  # @see https://haveibeenpwned.com/API/v2#PwnedPasswords
+  class PasswordBase
+    ##
+    # The base URL for the Pwned Passwords API
+    API_URL = "https://api.pwnedpasswords.com/range/"
+
+    ##
+    # The number of characters from the start of the hash of the password that
+    # are used to search for the range of passwords.
+    HASH_PREFIX_LENGTH = 5
+
+    ##
+    # The total length of a SHA1 hash
+    SHA1_LENGTH = 40
+
+    ##
+    # The default request headers that are used to make HTTP requests to the
+    # API. A user agent is provided as requested in the documentation.
+    # @see https://haveibeenpwned.com/API/v2#UserAgent
+    DEFAULT_REQUEST_HEADERS = {
+      "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}"
+    }.freeze
+
+    ##
+    # @example
+    #     password = Pwned::Password.new("password")
+    #     password.pwned? #=> true
+    #     password.pwned? #=> true
+    #
+    # @return [Boolean] +true+ when the password has been pwned.
+    # @raise [Pwned::Error] if there are errors with the HTTP request.
+    # @raise [Pwned::TimeoutError] if the HTTP request times out.
+    # @since 1.0.0
+    def pwned?
+      pwned_count > 0
+    end
+
+    ##
+    # @example
+    #     password = Pwned::Password.new("password")
+    #     password.pwned_count #=> 3303003
+    #
+    # @return [Integer] the number of times the password has been pwned.
+    # @raise [Pwned::Error] if there are errors with the HTTP request.
+    # @raise [Pwned::TimeoutError] if the HTTP request times out.
+    # @since 1.0.0
+    def pwned_count
+      @pwned_count ||= fetch_pwned_count
+    end
+
+    ##
+    # Returns the full SHA1 hash of the given password in uppercase.
+    # @return [String] The full SHA1 hash of the given password.
+    # @since 1.0.0
+    attr_reader :hashed_password
+
+    private
+
+    attr_reader :request_options, :request_headers
+
+    def fetch_pwned_count
+      for_each_response_line do |line|
+        next unless line.start_with?(hashed_password_suffix)
+        # Count starts after the suffix, followed by a colon
+        return line[(SHA1_LENGTH-HASH_PREFIX_LENGTH+1)..-1].to_i
+      end
+
+      # The hash was not found, we can assume the password is not pwned [yet]
+      0
+    end
+
+    def for_each_response_line(&block)
+      begin
+        with_http_response "#{API_URL}#{hashed_password_prefix}" do |response|
+          response.value # raise if request was unsuccessful
+          stream_response_lines(response, &block)
+        end
+      rescue Timeout::Error => e
+        raise Pwned::TimeoutError, e.message
+      rescue => e
+        raise Pwned::Error, e.message
+      end
+    end
+
+    def hashed_password_prefix
+      @hashed_password[0...HASH_PREFIX_LENGTH]
+    end
+
+    def hashed_password_suffix
+      @hashed_password[HASH_PREFIX_LENGTH..-1]
+    end
+
+    # Make a HTTP GET request given the url and headers.
+    # Yields a `Net::HTTPResponse`.
+    def with_http_response(url, &block)
+      uri = URI(url)
+
+      request = Net::HTTP::Get.new(uri)
+      request.initialize_http_header(request_headers)
+      request_options[:use_ssl] = true
+
+      Net::HTTP.start(uri.host, uri.port, request_options) do |http|
+        http.request(request, &block)
+      end
+    end
+
+    # Stream a Net::HTTPResponse by line, handling lines that cross chunks.
+    def stream_response_lines(response, &block)
+      last_line = ''
+
+      response.read_body do |chunk|
+        chunk_lines = (last_line + chunk).lines
+        # This could end with half a line, so save it for next time. If
+        # chunk_lines is empty, pop returns nil, so this also ensures last_line
+        # is always a string.
+        last_line = chunk_lines.pop || ''
+        chunk_lines.each(&block)
+      end
+
+      yield last_line unless last_line.empty?
+    end
+
+  end
+end

--- a/spec/pwned/hashed_password_spec.rb
+++ b/spec/pwned/hashed_password_spec.rb
@@ -1,0 +1,34 @@
+RSpec.describe Pwned::HashedPassword do
+  subject(:hashed_password) { Pwned::HashedPassword.new(password_hash) }
+
+  let(:password) { "password" }
+  let(:password_hash) { Pwned.hash_password(password) }
+
+  it "initializes with a password" do
+    expect(hashed_password.hashed_password).to eq("5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8")
+  end
+
+  context "when given an integer" do
+    let(:password_hash) { 123 }
+
+    it "doesn't initialize" do
+      expect { hashed_password }.to raise_error(TypeError)
+    end
+  end
+
+  context "when given an array" do
+    let(:password_hash) { ["hello", "world"] }
+
+    it "doesn't initialize" do
+      expect { hashed_password }.to raise_error(TypeError)
+    end
+  end
+
+  context "when given a hash" do
+    let(:password_hash) { { a: "b", c: "d" } }
+
+    it "doesn't initialize" do
+      expect { hashed_password }.to raise_error(TypeError)
+    end
+  end
+end

--- a/spec/pwned_spec.rb
+++ b/spec/pwned_spec.rb
@@ -2,4 +2,10 @@ RSpec.describe Pwned do
   it "has a version number" do
     expect(Pwned::VERSION).not_to be nil
   end
+
+  describe "#hash_password" do
+    it "returns an uppercase hash of the password" do
+      expect(Pwned.hash_password('password')).to eq('5BAA61E4C9B93F3F0682250B6CF8331B7EE68FD8')
+    end
+  end
 end


### PR DESCRIPTION
This allows callers to store the hashed password, and then call the pwned API at some later stage (e.g. to enqueue the job)

resolves https://github.com/philnash/pwned/issues/19