### PR TITLE
Use proxy from environment unless given in request options

### DIFF
--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -38,6 +38,7 @@ module Pwned
       @request_headers = Hash(request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
       @request_proxy = URI(request_options.delete(:proxy)) if request_options.key?(:proxy)
+      @find_proxy = request_options.delete(:find_proxy) || false
     end
   end
 end

--- a/lib/pwned/password_base.rb
+++ b/lib/pwned/password_base.rb
@@ -111,7 +111,7 @@ module Pwned
       Net::HTTP.start(
         uri.host,
         uri.port,
-        request_proxy&.host,
+        request_proxy&.host || :ENV,
         request_proxy&.port,
         request_proxy&.user,
         request_proxy&.password,

--- a/lib/pwned/password_base.rb
+++ b/lib/pwned/password_base.rb
@@ -65,7 +65,7 @@ module Pwned
 
     private
 
-    attr_reader :request_options, :request_headers, :request_proxy
+    attr_reader :request_options, :request_headers, :request_proxy, :find_proxy
 
     def fetch_pwned_count
       for_each_response_line do |line|
@@ -108,10 +108,12 @@ module Pwned
       request.initialize_http_header(request_headers)
       request_options[:use_ssl] = true
 
+      environment_proxy = find_proxy ? :ENV : nil
+
       Net::HTTP.start(
         uri.host,
         uri.port,
-        request_proxy&.host || :ENV,
+        request_proxy&.host || environment_proxy,
         request_proxy&.port,
         request_proxy&.user,
         request_proxy&.password,
@@ -136,6 +138,5 @@ module Pwned
 
       yield last_line unless last_line.empty?
     end
-
   end
 end


### PR DESCRIPTION
This is a PR to address [Not using https_proxy from the OS](https://github.com/philnash/pwned/issues/23)

- Leverage existing `Net::HTTP` behaviour to use the proxy defined in the environment unless a proxy is explicitly set using request options
- Update rspec to check the proxy fields on `Net::HTTP` instead of checking method arguments