### PR TITLE
Environment proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,28 +8,31 @@ An easy, Ruby way to use the Pwned Passwords API.
 
 ## Table of Contents
 
-- [Pwned](#pwned)
-  - [Table of Contents](#table-of-contents)
-  - [About](#about)
-  - [Installation](#installation)
-  - [Usage](#usage)
-    - [Plain Ruby](#plain-ruby)
-      - [Advanced](#advanced)
-    - [ActiveRecord Validator](#activerecord-validator)
-      - [I18n](#i18n)
-      - [Threshold](#threshold)
-      - [Network Error Handling](#network-error-handling)
-      - [Custom Request Options](#custom-request-options)
-    - [Using Asynchronously](#using-asynchronously)
-    - [Devise](#devise)
-    - [Rodauth](#rodauth)
-    - [Command line](#command-line)
-    - [Unpwn](#unpwn)
-  - [How Pwned is Pi?](#how-pwned-is-pi)
-  - [Development](#development)
-  - [Contributing](#contributing)
-  - [License](#license)
-  - [Code of Conduct](#code-of-conduct)
+* [Table of Contents](#table-of-contents)
+* [About](#about)
+* [Installation](#installation)
+* [Usage](#usage)
+  * [Plain Ruby](#plain-ruby)
+    * [Custom request options](#custom-request-options)
+      * [HTTP Headers](#http-headers)
+      * [HTTP Proxy](#http-proxy)
+  * [ActiveRecord Validator](#activerecord-validator)
+    * [I18n](#i18n)
+    * [Threshold](#threshold)
+    * [Network Error Handling](#network-error-handling)
+    * [Custom Request Options](#custom-request-options-1)
+      * [HTTP Headers](#http-headers-1)
+      * [HTTP Proxy](#http-proxy-1)
+  * [Using Asynchronously](#using-asynchronously)
+  * [Devise](#devise)
+  * [Rodauth](#rodauth)
+  * [Command line](#command-line)
+  * [Unpwn](#unpwn)
+* [How Pwned is Pi?](#how-pwned-is-pi)
+* [Development](#development)
+* [Contributing](#contributing)
+* [License](#license)
+* [Code of Conduct](#code-of-conduct)
 
 ## About
 
@@ -105,13 +108,49 @@ Pwned.pwned_count("password")
 #=> 3303003
 ```
 
-#### Advanced
+#### Custom request options
 
-You can set http request options to be used with `Net::HTTP.start` when making the request to the API. These options are
-documented in the [`Net::HTTP.start` documentation](http://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start). The `:headers` option defines defines HTTP headers. These headers must be string keys.
+You can set http request options to be used with `Net::HTTP.start` when making the request to the API. These options are documented in the [`Net::HTTP.start` documentation](https://ruby-doc.org/stdlib-3.0.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start). For example:
 
 ```ruby
-password = Pwned::Password.new("password", headers: { 'User-Agent' => 'Super fun new user agent' }, read_timeout: 10)
+password = Pwned::Password.new("password", read_timeout: 10)
+```
+
+##### HTTP Headers
+
+The `:headers` option defines defines HTTP headers. These headers must be string keys.
+
+```ruby
+password = Pwned::Password.new("password", headers: {
+  'User-Agent' => 'Super fun new user agent'
+})
+```
+
+##### HTTP Proxy
+
+An HTTP proxy can be set using the `http_proxy` environment variable:
+
+```ruby
+# Set in the environment
+ENV["http_proxy"] = "https://username:password@example.com:12345"
+
+# Will use the above proxy
+password = Pwned::Password.new("password")
+```
+
+You can specify a custom HTTP proxy with the `:proxy` option:
+
+```ruby
+password = Pwned::Password.new(
+  "password",
+  proxy: "https://username:password@example.com:12345"
+)
+```
+
+If you don't want to set a proxy and you don't want a proxy to be inferred from the environment, set the `:ignore_env_proxy` key:
+
+```ruby
+password = Pwned::Password.new("password", ignore_env_proxy: true)
 ```
 
 ### ActiveRecord Validator
@@ -181,16 +220,58 @@ end
 
 #### Custom Request Options
 
-You can configure network requests made from the validator using `:request_options` (see [Net::HTTP.start](http://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start) for the list of available options).
-In addition to these options, HTTP headers can be specified with the `:headers` key (e.g. `"User-Agent"`) and proxy can be specified with the `:proxy` key:
+You can configure network requests made from the validator using `:request_options` (see [Net::HTTP.start](http://ruby-doc.org/stdlib-2.6.3/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start) for the list of available options). 
 
 ```ruby
   validates :password, not_pwned: {
     request_options: {
       read_timeout: 5,
-      open_timeout: 1,
-      headers: { "User-Agent" => "Super fun user agent" },
+      open_timeout: 1
+    }
+  }
+```
+
+In addition to these options, you can also set the following:
+
+##### HTTP Headers
+
+HTTP headers can be specified with the `:headers` key (e.g. `"User-Agent"`)
+
+```ruby
+  validates :password, not_pwned: {
+    request_options: {
+      headers: { "User-Agent" => "Super fun user agent" }
+    }
+  }
+```
+
+##### HTTP Proxy
+
+An HTTP proxy can be set using the `http_proxy` environment variable:
+
+```ruby
+  # Set in the environment
+  ENV["http_proxy"] = "https://username:password@example.com:12345"
+
+  validates :password, not_pwned: true
+```
+
+You can specify a custom HTTP proxy with the `:proxy` key:
+
+```ruby
+  validates :password, not_pwned: {
+    request_options: {
       proxy: "https://username:password@example.com:12345"
+    }
+  }
+```
+
+If you don't want to set a proxy and you don't want a proxy to be inferred from the environment, set the `:ignore_env_proxy` key:
+
+```ruby
+  validates :password, not_pwned: {
+    request_options: {
+      ignore_env_proxy: true
     }
   }
 ```
@@ -204,6 +285,8 @@ hashed_password = Pwned.hash_password(password)
 # some time later
 Pwned::HashPassword.new(hashed_password, request_options).pwned?
 ```
+
+The `Pwned::HashPassword` constructor takes all the same options as the regular `Pwned::Password` contructor.
 
 ### Devise
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ password = Pwned::Password.new("password", headers: {
 
 ##### HTTP Proxy
 
-An HTTP proxy can be set using the `http_proxy` environment variable:
+An HTTP proxy can be set using the `http_proxy` or `HTTP_PROXY` environment variable. This is the same way that `Net::HTTP` handles HTTP proxies if no proxy options are given. See [`URI::Generic#find_proxy`](https://ruby-doc.org/stdlib-3.0.1/libdoc/uri/rdoc/URI/Generic.html#method-i-find_proxy) for full details on how Ruby detects a proxy from the environment.
 
 ```ruby
 # Set in the environment
@@ -247,7 +247,7 @@ HTTP headers can be specified with the `:headers` key (e.g. `"User-Agent"`)
 
 ##### HTTP Proxy
 
-An HTTP proxy can be set using the `http_proxy` environment variable:
+An HTTP proxy can be set using the `http_proxy` or `HTTP_PROXY` environment variable. This is the same way that `Net::HTTP` handles HTTP proxies if no proxy options are given. See [`URI::Generic#find_proxy`](https://ruby-doc.org/stdlib-3.0.1/libdoc/uri/rdoc/URI/Generic.html#method-i-find_proxy) for full details on how Ruby detects a proxy from the environment.
 
 ```ruby
   # Set in the environment

--- a/lib/pwned.rb
+++ b/lib/pwned.rb
@@ -35,6 +35,9 @@ module Pwned
   #   calling the API
   # @option request_options [Symbol] :headers ({ "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })
   #   HTTP headers to include in the request
+  # @option request_options [Symbol] :ignore_env_proxy (false) The library
+  #   will try to infer an HTTP proxy from the `http_proxy` environment
+  #   variable. If you do not want this behaviour, set this option to true.
   # @return [Boolean] Whether the password appears in the data breaches or not.
   # @since 1.1.0
   def self.pwned?(password, request_options={})
@@ -53,6 +56,9 @@ module Pwned
   #   calling the API
   # @option request_options [Symbol] :headers ({ "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })
   #   HTTP headers to include in the request
+  # @option request_options [Symbol] :ignore_env_proxy (false) The library
+  #   will try to infer an HTTP proxy from the `http_proxy` environment
+  #   variable. If you do not want this behaviour, set this option to true.
   # @return [Integer] The number of times the password has appeared in the data
   #   breaches.
   # @since 1.1.0

--- a/lib/pwned/hashed_password.rb
+++ b/lib/pwned/hashed_password.rb
@@ -22,6 +22,9 @@ module Pwned
     #   calling the API
     # @option request_options [Symbol] :headers ({ "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })
     #   HTTP headers to include in the request
+    # @option request_options [Symbol] :ignore_env_proxy (false) The library
+    #   will try to infer an HTTP proxy from the `http_proxy` environment
+    #   variable. If you do not want this behaviour, set this option to true.
     # @raise [TypeError] if the password is not a string.
     # @since 2.1.0
     def initialize(hashed_password, request_options={})
@@ -31,6 +34,7 @@ module Pwned
       @request_headers = Hash(request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
       @request_proxy = URI(request_options.delete(:proxy)) if request_options.key?(:proxy)
+      @ignore_env_proxy = request_options.delete(:ignore_env_proxy) || false
     end
   end
 end

--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -38,6 +38,7 @@ module Pwned
       @request_headers = Hash(request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
       @request_proxy = URI(request_options.delete(:proxy)) if request_options.key?(:proxy)
+      @find_proxy = request_options.delete(:find_proxy) || false
     end
   end
 end

--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -27,7 +27,9 @@ module Pwned
     #   calling the API
     # @option request_options [Symbol] :headers ({ "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })
     #   HTTP headers to include in the request
-    # @return [Boolean] Whether the password appears in the data breaches or not.
+    # @option request_options [Symbol] :ignore_env_proxy (false) The library
+    #   will try to infer an HTTP proxy from the `http_proxy` environment
+    #   variable. If you do not want this behaviour, set this option to true.
     # @raise [TypeError] if the password is not a string.
     # @since 1.1.0
     def initialize(password, request_options={})
@@ -38,7 +40,7 @@ module Pwned
       @request_headers = Hash(request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
       @request_proxy = URI(request_options.delete(:proxy)) if request_options.key?(:proxy)
-      @find_proxy = request_options.delete(:find_proxy) || false
+      @ignore_env_proxy = request_options.delete(:ignore_env_proxy) || false
     end
   end
 end

--- a/lib/pwned/password_base.rb
+++ b/lib/pwned/password_base.rb
@@ -65,7 +65,7 @@ module Pwned
 
     private
 
-    attr_reader :request_options, :request_headers, :request_proxy, :find_proxy
+    attr_reader :request_options, :request_headers, :request_proxy, :ignore_env_proxy
 
     def fetch_pwned_count
       for_each_response_line do |line|
@@ -108,7 +108,7 @@ module Pwned
       request.initialize_http_header(request_headers)
       request_options[:use_ssl] = true
 
-      environment_proxy = find_proxy ? :ENV : nil
+      environment_proxy = ignore_env_proxy ? nil : :ENV
 
       Net::HTTP.start(
         uri.host,

--- a/lib/pwned/password_base.rb
+++ b/lib/pwned/password_base.rb
@@ -111,7 +111,7 @@ module Pwned
       Net::HTTP.start(
         uri.host,
         uri.port,
-        request_proxy&.host,
+        request_proxy&.host || :ENV,
         request_proxy&.port,
         request_proxy&.user,
         request_proxy&.password,

--- a/lib/pwned/password_base.rb
+++ b/lib/pwned/password_base.rb
@@ -65,7 +65,7 @@ module Pwned
 
     private
 
-    attr_reader :request_options, :request_headers, :request_proxy
+    attr_reader :request_options, :request_headers, :request_proxy, :find_proxy
 
     def fetch_pwned_count
       for_each_response_line do |line|
@@ -108,10 +108,12 @@ module Pwned
       request.initialize_http_header(request_headers)
       request_options[:use_ssl] = true
 
+      environment_proxy = find_proxy ? :ENV : nil
+
       Net::HTTP.start(
         uri.host,
         uri.port,
-        request_proxy&.host || :ENV,
+        request_proxy&.host || environment_proxy,
         request_proxy&.port,
         request_proxy&.user,
         request_proxy&.password,
@@ -136,6 +138,5 @@ module Pwned
 
       yield last_line unless last_line.empty?
     end
-
   end
 end


### PR DESCRIPTION
Builds on the work from #24. Restores the default behaviour of Net::HTTP with an environment set HTTP proxy. Documents the changes in comments and the README.

I think we actually broke the default behaviour of Net::HTTP when introducing the `proxy` option in #21. I see this as fixing that, plus allowing for users to declare their own explicit proxy and choose to ignore the environment proxy if they want to (much as [the faraday gem does](https://lostisland.github.io/faraday/usage/customize)).