### PR TITLE
Add global default request_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,18 @@ Pwned.pwned_count("password")
 
 #### Custom request options
 
-You can set http request options to be used with `Net::HTTP.start` when making the request to the API. These options are documented in the [`Net::HTTP.start` documentation](https://ruby-doc.org/stdlib-3.0.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start). For example:
+You can set HTTP request options to be used with `Net::HTTP.start` when making the request to the API. These options are documented in the [`Net::HTTP.start` documentation](https://ruby-doc.org/stdlib-3.0.0/libdoc/net/http/rdoc/Net/HTTP.html#method-c-start).
+
+You can pass the options to the constructor:
 
 ```ruby
 password = Pwned::Password.new("password", read_timeout: 10)
+```
+
+You can also specify global defaults:
+
+```ruby
+Pwned.default_request_options = { read_timeout: 10 }
 ```
 
 ##### HTTP Headers
@@ -230,6 +238,8 @@ You can configure network requests made from the validator using `:request_optio
     }
   }
 ```
+
+These options override the globally defined default options (see above).
 
 In addition to these options, you can also set the following:
 

--- a/lib/pwned.rb
+++ b/lib/pwned.rb
@@ -23,6 +23,29 @@ end
 # results for a password.
 
 module Pwned
+  @default_request_options = {}
+
+  ##
+  # The default request options passed to +Net::HTTP.start+ when calling the API.
+  #
+  # @return [Hash]
+  # @see Pwned::Password#initialize
+  def self.default_request_options
+    @default_request_options
+  end
+
+  ##
+  # Sets the default request options passed to +Net::HTTP.start+ when calling
+  # the API.
+  #
+  # The default options may be overridden in +Pwned::Password#new+.
+  #
+  # @param [Hash] request_options
+  # @see Pwned::Password#initialize
+  def self.default_request_options=(request_options)
+    @default_request_options = request_options
+  end
+
   ##
   # Returns +true+ when the password has been pwned.
   #

--- a/lib/pwned/hashed_password.rb
+++ b/lib/pwned/hashed_password.rb
@@ -19,7 +19,7 @@ module Pwned
     #
     # @param hashed_password [String] The hash of the password you want to check against the API.
     # @param [Hash] request_options Options that can be passed to +Net::HTTP.start+ when
-    #   calling the API
+    #   calling the API. This overrides any keys specified in +Pwned.default_request_options+.
     # @option request_options [Symbol] :headers ({ "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })
     #   HTTP headers to include in the request
     # @option request_options [Symbol] :ignore_env_proxy (false) The library
@@ -30,11 +30,11 @@ module Pwned
     def initialize(hashed_password, request_options={})
       raise TypeError, "hashed_password must be of type String" unless hashed_password.is_a? String
       @hashed_password = hashed_password.upcase
-      @request_options = Hash(request_options).dup
-      @request_headers = Hash(request_options.delete(:headers))
+      @request_options = Pwned.default_request_options.merge(request_options)
+      @request_headers = Hash(@request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
-      @request_proxy = URI(request_options.delete(:proxy)) if request_options.key?(:proxy)
-      @ignore_env_proxy = request_options.delete(:ignore_env_proxy) || false
+      @request_proxy = URI(@request_options.delete(:proxy)) if @request_options.key?(:proxy)
+      @ignore_env_proxy = @request_options.delete(:ignore_env_proxy) || false
     end
   end
 end

--- a/lib/pwned/password.rb
+++ b/lib/pwned/password.rb
@@ -24,7 +24,7 @@ module Pwned
     #
     # @param password [String] The password you want to check against the API.
     # @param [Hash] request_options Options that can be passed to +Net::HTTP.start+ when
-    #   calling the API
+    #   calling the API. This overrides any keys specified in +Pwned.default_request_options+.
     # @option request_options [Symbol] :headers ({ "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })
     #   HTTP headers to include in the request
     # @option request_options [Symbol] :ignore_env_proxy (false) The library
@@ -36,11 +36,11 @@ module Pwned
       raise TypeError, "password must be of type String" unless password.is_a? String
       @password = password
       @hashed_password = Pwned.hash_password(password)
-      @request_options = Hash(request_options).dup
-      @request_headers = Hash(request_options.delete(:headers))
+      @request_options = Pwned.default_request_options.merge(request_options)
+      @request_headers = Hash(@request_options.delete(:headers))
       @request_headers = DEFAULT_REQUEST_HEADERS.merge(@request_headers)
-      @request_proxy = URI(request_options.delete(:proxy)) if request_options.key?(:proxy)
-      @ignore_env_proxy = request_options.delete(:ignore_env_proxy) || false
+      @request_proxy = URI(@request_options.delete(:proxy)) if @request_options.key?(:proxy)
+      @ignore_env_proxy = @request_options.delete(:ignore_env_proxy) || false
     end
   end
 end

--- a/spec/pwned/not_pwned_validator_spec.rb
+++ b/spec/pwned/not_pwned_validator_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe NotPwnedValidator do
     end
 
     it "allows the user agent to be set" do
+      # Default option should be overridden
+      Pwned.default_request_options = { headers: { "User-Agent" => "Default user agent" } }
+
       Model.validates :password, not_pwned: {
         request_options: { headers: { "User-Agent" => "Super fun user agent" } }
       }
@@ -44,7 +47,10 @@ RSpec.describe NotPwnedValidator do
         to have_been_made.once
     end
 
-    it "allows the proxy to be set" do
+    it "allows the proxy to be set via options" do
+      # Default option should be overridden
+      Pwned.default_request_options = { proxy: "https://username:password@default.com:12345" }
+
       Model.validates :password, not_pwned: {
         request_options: { proxy: "https://username:password@example.com:12345" }
       }
@@ -54,6 +60,23 @@ RSpec.describe NotPwnedValidator do
       # so we check that Net::HTTP receives the correct arguments.
       expect(Net::HTTP).to receive(:start).
         with("api.pwnedpasswords.com", 443, "example.com", 12345, "username", "password", anything).
+        and_call_original
+
+      expect(model).to_not be_valid
+      expect(a_request(:get, "https://api.pwnedpasswords.com/range/5BAA6").
+        with(headers: { "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" })).
+        to have_been_made.once
+    end
+
+    it "allows the proxy to be set via default options" do
+      Pwned.default_request_options = { proxy: "https://username:password@default.com:12345" }
+      Model.validates :password, not_pwned: true
+      model = create_model("password")
+
+      # Webmock doesn't support proxy assertions (https://github.com/bblimke/webmock/issues/753)
+      # so we check that Net::HTTP receives the correct arguments.
+      expect(Net::HTTP).to receive(:start).
+        with("api.pwnedpasswords.com", 443, "default.com", 12345, "username", "password", anything).
         and_call_original
 
       expect(model).to_not be_valid

--- a/spec/pwned/password_spec.rb
+++ b/spec/pwned/password_spec.rb
@@ -140,12 +140,23 @@ RSpec.describe Pwned::Password do
         to have_been_made.once
     end
 
-    it "allows the user agent to be set" do
+    it "allows the user agent to be set in constructor" do
+      Pwned.default_request_options = { headers: { "User-Agent" => "Default user agent" } }
       password = Pwned::Password.new("password", headers: { "User-Agent" => "Super fun user agent" })
       password.pwned?
 
       expect(a_request(:get, "https://api.pwnedpasswords.com/range/5BAA6").
         with(headers: { "User-Agent" => "Super fun user agent" })).
+        to have_been_made.once
+    end
+
+    it "allows the user agent to be set with default settings" do
+      Pwned.default_request_options = { headers: { "User-Agent" => "Default user agent" } }
+      password = Pwned::Password.new("password")
+      password.pwned?
+
+      expect(a_request(:get, "https://api.pwnedpasswords.com/range/5BAA6").
+        with(headers: { "User-Agent" => "Default user agent" })).
         to have_been_made.once
     end
 
@@ -272,6 +283,28 @@ RSpec.describe Pwned::Password do
       context "ignore_env_proxy is false" do
         before { request_options[:ignore_env_proxy] = false }
         include_examples "doesn't use proxy from environment"
+      end
+    end
+
+    context "proxy given in default request options" do
+      before { Pwned.default_request_options = { proxy: "https://username:password@default.com:12345" } }
+
+      it "uses proxy from the default require options" do
+        expect(Net::HTTP).to receive(:start).and_wrap_original do |original_method, *args, &block|
+          http = original_method.call(*args)
+          expect(http.proxy_from_env?).to eq(false)
+          expect(http.proxy_address).to eq("default.com")
+          expect(http.proxy_user).to eq("username")
+          expect(http.proxy_pass).to eq("password")
+          expect(http.proxy_port).to eq(12_345)
+          original_method.call(*args, &block)
+        end
+
+        subject
+
+        expect(a_request(:get, "https://api.pwnedpasswords.com/range/5BAA6")
+          .with(headers: { "User-Agent" => "Ruby Pwned::Password #{Pwned::VERSION}" }))
+          .to have_been_made.once
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,4 +18,8 @@ RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect
   end
+
+  config.after do |c|
+    Pwned.default_request_options = {}
+  end
 end


### PR DESCRIPTION
Instead of specifying `request_options` on all validators in your code, it would be useful to be able to specify global defaults.